### PR TITLE
[BUGFIX] Undeclared arguments passed to ViewHelper

### DIFF
--- a/Classes/ViewHelpers/DataLayerViewHelper.php
+++ b/Classes/ViewHelpers/DataLayerViewHelper.php
@@ -38,10 +38,23 @@ class DataLayerViewHelper extends AbstractViewHelper
     /**
      * @param string $name
      * @param string $value
+     * Initialize arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('name', 'string', 'name', true);
+        $this->registerArgument('value', 'string', 'value', true);
+    }
+
+    /**
      * @return string
      */
-    public function render($name, $value)
+    public function render()
     {
+        $name = $this->arguments['name'];
+        $value = $this->arguments['value'];
+
         if ($value === null) {
             return '';
         }


### PR DESCRIPTION
This fixes the following exception shown in TYPO3 9.5: 

`Undeclared arguments passed to ViewHelper Aoe\GoogleTagManager\ViewHelpers\DataLayerViewHelper: name, value. Valid arguments are: `